### PR TITLE
fix(rest): fix cors header, disable csrf in spring

### DIFF
--- a/appserver/src/main/java/com/marklogic/sampleStack/ApplicationSecurity.java
+++ b/appserver/src/main/java/com/marklogic/sampleStack/ApplicationSecurity.java
@@ -23,6 +23,9 @@ public class ApplicationSecurity extends WebSecurityConfigurerAdapter {
                 .and()
             .logout()
                 .permitAll();
+        http       
+            .csrf()
+                .disable();
     }
 	
 	@Override

--- a/appserver/src/main/java/com/marklogic/sampleStack/web/SampleStackCorsFilter.java
+++ b/appserver/src/main/java/com/marklogic/sampleStack/web/SampleStackCorsFilter.java
@@ -21,7 +21,7 @@ public class SampleStackCorsFilter implements Filter {
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
 		response.setHeader("Access-Control-Max-Age", "3600");
-		response.setHeader("Access-Control-Allow-Headers", "x-requested-with");
+		response.setHeader("Access-Control-Allow-Headers", "x-requested-with, content-type");
 		chain.doFilter(req, res);
 	}
 


### PR DESCRIPTION
Please verify that the CORS/CSRF changes are OK and look into why the REST endpoint is sending a redirect to:

http://localhost:8080/login

Can you merge and then we can open a new issue on the login redirect.
