### PR TITLE
appRouting - remove hierarchy definition shorthand

### DIFF
--- a/browser/src/app/services/appRouting.js
+++ b/browser/src/app/services/appRouting.js
@@ -36,86 +36,6 @@ define(['app/module'], function (module) {
       .hashPrefix('');
   };
 
-  // /**
-  //  * Assign fullnames to states
-  //  * @param {[type]} parentalPrefix [description]
-  //  * @param {[type]} state          [description]
-  //  */
-  // var setFullNames = function (parentalPrefix, state) {
-  //
-  // };
-
-  var setStateDefaults = function (parentPrefix, state) {
-    state.fullName = parentPrefix + state.name;
-    if (_.isUndefined(state.views)) {
-      setViewDefaults(state);
-    }
-    else {
-      _.forEach(state.views, function (view, name) {
-        view.fullName = name.indexOf('@') >= 0 ?
-            name :
-            name + '@' + state.fullName;
-
-        // view.fullName = view.fullName
-        //     .replace(/^root\./, '')
-        //     .replace(/@root/, '@')
-        //     .replace(/^layout\./, '')
-        //     .replace(/@\.layout/, '@')
-        //     .replace(/@\./, '@')
-        //     .replace(/@$/, '');
-
-        setViewDefaults(view);
-      });
-    }
-    _.forEach(state.children, function (child) {
-      setStateDefaults(state.fullName + '.', child);
-    });
-
-  };
-
-  /**
-   * Defaults a filename for a view's template if it is undefined (as opposed to
-   * null).
-   * Defaults a controller for a view if it is undefined (as opposed to null).
-   *
-   * Assumes that a view has already had its fullname inferred.
-   * @param {Object} view A state or view.
-   */
-  var setViewDefaults = function (view) {
-    // make a short name so filenames don't have root and layout all over
-    // the place
-    var shortName = view.fullName
-        .replace(/^root\./, '') //remove root. prefix
-        .replace(/^layout\./, '') //remove remaining layout. prefix
-        .replace(/@root$/, '@') //remove @root suffix
-        .replace(/@\.layout/, '@') //remove @.layout suffix
-        .replace(/@\./, '@') //remove @. suffix
-        .replace(new RegExp('@' + view.name), '@') //remove @viewname suffix
-        .replace(/@$/, ''); //remove trailing @
-
-    if (!shortName.length) {
-      // if there is nothing left of the shortname, use the fullname absent
-      // the @ sign
-      shortName = view.fullName.replace(/@/, '');
-    }
-
-    if (_.isUndefined(view.templateUrl)) {
-      // templateurl needs dashes and $ signs for legality/clarity
-      view.templateUrl = '/app/states/' + shortName
-          .replace(/@/g, '$')
-          .replace(/\./g, '-');
-      view.templateUrl += '.html';
-    }
-    if (_.isUndefined(view.controller)) {
-      // controller name is simplified -- if these rules aren't specific
-      // enough, then name the controller manually
-      view.controller = shortName
-          .replace(/-/g, '')
-          .replace(/@/g, '');
-      view.controller += 'Ctlr';
-    }
-  };
-
   var attachEvents = function ($rootScope) {
     // TODO: handle these more gracefully!
     // this should be the role of the stateManager
@@ -169,7 +89,6 @@ define(['app/module'], function (module) {
       // which are always abstract in state names
 
       this.configure = function (hierarchy) {
-        setStateDefaults('', hierarchy);
         stateHelperProvider.setNestedState(hierarchy);
       };
 

--- a/browser/src/app/states/_statesHierarchy.js
+++ b/browser/src/app/states/_statesHierarchy.js
@@ -3,44 +3,51 @@ define(
     'app/module',
   ],
   function (module) {
+
     var root = {
       name: 'root',
       abstract: true,
       url: '',
-      children: [],
-      templateUrl: '/app/states/_root.html'
+      controller: 'rootCtlr',
+      templateUrl: '/app/states/_root.html',
+      children: [
+        {
+          name: 'layout',
+          abstract: true,
+          controller: 'layoutCtlr',
+          templateUrl: '/app/states/_layout.html'
+        }
+      ]
     };
 
-    var layout = {
-      name: 'layout',
-      abstract: true,
-      templateUrl: '/app/states/_layout.html'
-    };
-    root.children.push(layout);
-
-    layout.children = [
-      // {
-      //   name: 'documents',
-      //   url: '/' // there will be a bunch of URL parameters possible
-      // },
+    root.children[0].children = [
       {
         name: 'fourOhFour',
         url: '/404',
+        controller: 'fourOhFourCtlr',
+        templateUrl: '/app/states/fourOhFour.html'
       },
       {
         name: 'explore',
         // will deal with all sorts of parameters here, potentially
         // as sub-states
-        url: '/'
+        url: '/',
+        controller: 'exploreCtlr',
+        templateUrl: '/app/states/explore.html'
       },
       {
         name: 'qnaDoc',
-        url: '/doc/:id'
+        url: '/doc/:id',
+        controller: 'qnaDocCtlr',
+        templateUrl: '/app/states/qnaDoc.html'
       },
       {
         name: 'ask',
-        url: '/ask'
+        url: '/ask',
+        controller: 'askCtlr',
+        templateUrl: '/app/states/ask.html'
       }
+
     ];
 
     module.constant('statesHierarchy', root);


### PR DESCRIPTION
Using shorthand to define states hierarchy has been found to be
confusing to new developers. Remove shorthand and associated
interpretation code.
