### PR TITLE
java/search: allow start as object property

### DIFF
--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/web/QnADocumentController.java
@@ -182,8 +182,14 @@ public class QnADocumentController {
 	
 	@RequestMapping(value = "search", method = RequestMethod.POST)
 	public @ResponseBody
-	JsonNode search(@RequestBody JsonNode structuredQuery,
+	JsonNode search(@RequestBody ObjectNode structuredQuery,
 			@RequestParam(defaultValue = "1", required = false) long start) {
+
+		JsonNode postedStartNode = structuredQuery.get("start");
+		if (postedStartNode != null) {
+			start = postedStartNode.asLong();
+			structuredQuery.remove("start");
+		}
 		return qnaService.rawSearch(ClientRole.securityContextRole(), structuredQuery, start);
 	}
 


### PR DESCRIPTION
Allow start to be specified on the root of the posted object as an
alternative to using the query string parameter.

(This makes it easier to manage the search as a single object.)
