### PR TITLE
browser/build: windows SASS build

### DIFF
--- a/browser/dev-tasks/tasks.js
+++ b/browser/dev-tasks/tasks.js
@@ -289,7 +289,7 @@ var buildStream = function (stream) {
     'bower_components/bourbon/dist',
     'bower_components/bitters/app/assets/stylesheets',
     'bower_components/neat/app/assets/stylesheets'
-  ]
+  ];
 
   var sassPipe;
   var sassParams;
@@ -327,7 +327,9 @@ var buildStream = function (stream) {
       includePaths: [bootstrapDir] //otherDirs // .concat(bootstrapDir)
     };
 
-    if (buildParams.sassCompiler !== 'node-sass-safe') {
+    if (buildParams.sassCompiler !== 'node-sass-safe' &&
+        process.platform !== 'win32'
+    ) {
       sassParams.sourceComments = 'map';
       sassParams.sourceMap = 'sass';
     }


### PR DESCRIPTION
gulp-sass is problematic in windows with sourcemaps enabled.

Disable SASS sourcemaps in Windows environment until gulp-sass is fixed.
