### PR TITLE
browser/build: remove slash from app definition of reps path

### DIFF
--- a/browser/src/_marklogic/deps.js
+++ b/browser/src/_marklogic/deps.js
@@ -25,9 +25,6 @@ require.config({
     },
     'angular-cookies': {
       deps: ['angular']
-    },
-    'restangular': {
-      deps: ['angular', 'lodash']
     }
   }
 });

--- a/browser/src/app/deps.js
+++ b/browser/src/app/deps.js
@@ -7,8 +7,6 @@ names.
 
 require.config({
   paths: {
-    'deps': '/deps',
-
     'lodash': 'deps/lodash/dist/lodash.compat<%=min%>',
     'angular': 'deps/angular/angular<%=min%>',
     'ui-router': 'deps/angular-ui-router/release/angular-ui-router<%=min%>',


### PR DESCRIPTION
The app module was overriding reps path when combined with the marklogic
module.  Remove path definition to reps from apps as well.

Also eliminate stray path to rectangular which has been excised.
