### PR TITLE
browser/build: make moment global

### DIFF
--- a/browser/src/_marklogic/deps.js
+++ b/browser/src/_marklogic/deps.js
@@ -31,13 +31,16 @@ require.config({
 
 define(
   [
+    'moment',
     'angular',
     'angular-cookies'
   ],
-  function (angular) {
+  function (moment, angular) {
 
     // angular is made global as a convenience.
     window.angular = angular;
+
+    window.moment = moment;
 
     // we won't introduce any angular dependencies -- otherwisethis would be
     // an array

--- a/browser/src/_marklogic/filters/iso8601.js
+++ b/browser/src/_marklogic/filters/iso8601.js
@@ -1,4 +1,4 @@
-define(['_marklogic/module', 'moment'], function (module, moment) {
+define(['_marklogic/module'], function (module) {
 
   /**
    * @ngdoc filter
@@ -12,7 +12,7 @@ define(['_marklogic/module', 'moment'], function (module, moment) {
         return undefined;
       }
       else {
-        return moment(date).toISOString();
+        return window.moment(date).toISOString();
       }
     };
   });
@@ -29,7 +29,7 @@ define(['_marklogic/module', 'moment'], function (module, moment) {
         return undefined;
       }
       else {
-        return moment(str).toDate();
+        return window.moment(str).toDate();
       }
     };
   });


### PR DESCRIPTION
Linux version of phantom for unknown reasons seems to be unhappy
finding moment unless it is required up front. Define moment
on window in deps.js to workaround.
