### PR TITLE
fix(unit tests): avoid chai's should on numbers

### DIFF
--- a/browser/test/unit-tests/_marklogic/domain/mlSearch.unit.js
+++ b/browser/test/unit-tests/_marklogic/domain/mlSearch.unit.js
@@ -455,7 +455,7 @@ define([
         });
 
         s.criteria.q.should.equal('stuff');
-        s.getCurrentPage().should.equal(2);
+        expect(s.getCurrentPage()).to.equal(2);
         s.criteria.constraints.should.deep.equal({
           a: { type: 'boolean', queryStringName: 'a', value: true },
           b: { type: 'text', queryStringName: 'b', value: 'test' },

--- a/browser/test/unit-tests/_marklogic/services/data/mlHttpInterceptor.unit.js
+++ b/browser/test/unit-tests/_marklogic/services/data/mlHttpInterceptor.unit.js
@@ -91,8 +91,8 @@ define(['testHelper'], function (helper) {
             $http.put('/v1/second')
           ]).then(
             function (responses) {
-              responses[0].status.should.equal(200);
-              responses[1].status.should.equal(200);
+              expect(responses[0].status).to.equal(200);
+              expect(responses[1].status).to.equal(200);
               done();
             },
             function (reason) { assert(JSON.stringify(reason)); done(); }

--- a/browser/test/unit-tests/_marklogic/services/data/mlModelBase.unit.js
+++ b/browser/test/unit-tests/_marklogic/services/data/mlModelBase.unit.js
@@ -526,7 +526,7 @@ define(['testHelper'], function (helper) {
         var inst = impl1.create({
           id: '1'
         });
-        inst.errors('').length.should.equal(1);
+        expect(inst.errors('').length).to.equal(1);
       });
 
       it('can find an error on a property', function () {
@@ -536,7 +536,7 @@ define(['testHelper'], function (helper) {
           myProp2: {},
           myProp3: {}
         });
-        inst.errors('myProp3').length.should.equal(1);
+        expect(inst.errors('myProp3').length).to.equal(1);
       });
 
       it('can inform of zero errors on a property', function () {
@@ -544,7 +544,7 @@ define(['testHelper'], function (helper) {
           id: '1',
           myProp2: {}
         });
-        inst.errors('myProp2').length.should.equal(0);
+        expect(inst.errors('myProp2').length).to.equal(0);
       });
 
       it('can answer whether a property is valid', function () {
@@ -560,7 +560,7 @@ define(['testHelper'], function (helper) {
           id: '1',
           myProp4: {}
         });
-        inst.errors('myProp4').length.should.equal(2);
+        expect(inst.errors('myProp4').length).to.equal(2);
       });
 
       it(

--- a/browser/test/unit-tests/_marklogic/services/data/mlWaiter.unit.js
+++ b/browser/test/unit-tests/_marklogic/services/data/mlWaiter.unit.js
@@ -27,7 +27,7 @@ define(['testHelper'], function (testHelper) {
           function () {
             obj.$ml.should.not.have.property('error');
             obj.$ml.should.not.have.property('wating');
-            obj.value.should.equal(1);
+            expect(obj.value).to.equal(1);
             done();
           }
         );

--- a/browser/test/unit-tests/app/dialogs/login.unit.js
+++ b/browser/test/unit-tests/app/dialogs/login.unit.js
@@ -99,7 +99,7 @@ define([
           scope.authenticate();
           $httpBackend.flush();
           $timeout.flush();
-          modalClose.args[0].length.should.equal(1);
+          expect(modalClose.args[0].length).to.equal(1);
         });
 
         it('can handle bad auth', function () {


### PR DESCRIPTION
Chai's should assertions are failing to function on IE9.

Switch each failing usage to `expect` syntax which should work
the same universally.

This addresses part of what is in issue 169
