### PR TITLE
browser: angular's to/from Json instead of manual conversion

### DIFF
--- a/browser/src/_marklogic/services/data/mlModelBase.js
+++ b/browser/src/_marklogic/services/data/mlModelBase.js
@@ -231,13 +231,10 @@ define(['_marklogic/module'], function (module) {
       };
 
       MlModel.prototype.validateObject = function (obj) {
-        var own = {};
-        Object.getOwnPropertyNames(obj).reduce(
-          function (dummy, key) {
-            own[key] = obj[key];
-          }
+        return mlSchema.validate(
+          angular.fromJson(angular.toJson(obj)),
+          this.$mlSpec.schema.id
         );
-        return mlSchema.validate(dedate(own), this.$mlSpec.schema.id);
       };
 
       MlModel.prototype.testValidity = function () {


### PR DESCRIPTION
In order to determine what parts of an object are "jsonifiable",
convert the object to/from JSON.  This avoids use go getOwnPropertyNames,
which seems to be behaving differently in different browsers.
