### PR TITLE
browser: use request for proxying

### DIFF
--- a/browser/dev-tasks/tasks.js
+++ b/browser/dev-tasks/tasks.js
@@ -463,12 +463,17 @@ process.on('SIGINT', function () {
 function startServer (path, port) {
   if (!getActiveServer(port)) {
     var connect = require('connect');
-    var url = require('url');
-    var proxy = require('proxy-middleware');
     var serveStatic = require('serve-static');
+    var request = require('request');
 
     var server = connect()
-      .use('/v1', proxy(url.parse('http://localhost:8090/v1')))
+      .use('/v1/', function (req, res) {
+        req.pipe(
+          request(
+            buildParams.build.restUrl + '/v1/' + req.url
+          )
+        ).pipe(res);
+      })
       .use(
         require('connect-modrewrite')(
         // if lacking a dot, redirect to index.html

--- a/browser/package.json
+++ b/browser/package.json
@@ -66,7 +66,7 @@
     "open": "0.0.5",
     "phantomjs": "1.9.7-14",
     "protractor": "1.0.0",
-    "proxy-middleware": "0.5.0",
+    "request": "2.40.0",
     "selenium-webdriver": "2.42.1",
     "serve-static": "1.4.2",
     "shelljs": "0.3.0",


### PR DESCRIPTION
Switch to mikeal/request to proxy for rest server.  "proxy/middleware"
was unstable.
