### PR TITLE
chore(readme): update instructions for nightly, add note on cleanstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This README covers the following topics:
 ## Prerequisites
 To configure and use this application, you need the following software:
 * Java JDK 1.7 or 1.8
-* MarkLogic 8.0 Nightly from 11/7/2014 (see instructions [below](#getting-started))
+* Latest MarkLogic 8.0 Nightly Build (see instructions [below](#getting-started))
 * Node.js, version 0.10 or later. See [nodejs.org](http://nodejs.org).
 * A global installation of the Node.js components [bower](http://bower.io) and [gulp](https://github.com/gulpjs/gulp). For details, see [Global Utilities](browser/README.md#global-utilities) in the [browser README](browser/README.md).
 
@@ -36,17 +36,22 @@ The setup procedure may install additional software, such as Gradle and Angular.
 
 This README is for a development branch that does not work with any released version of MarkLogic
 
-Use MarkLogic nightly dated 11/7.  
+Use Latest MarkLogic nightly for your platform:
 
-RPM link: https://root.marklogic.com/nightly/builds/linux64/rh6-intel64-80-test-1.marklogic.com/HEAD/pkgs.20141107/MarkLogic-8.0-20141107.x86_64.rpm
+http://root.marklogic.com/nightly/default.xqy?branch=HEAD
 
-Trunk does NOT work for this PR.
 Java Client API needs snapshot available on commit [481c2b045ad5bc6f0549ad4e60e44b7cec5232a6](https://github.com/marklogic/java-client-api/commit/481c2b045ad5bc6f0549ad4e60e44b7cec5232a6) from 11/5/2014.  This should be installed
 automatically but may require gradle or maven cache cleaning.
 
 This build requires seed data available internally.  The current seed data version is 1.3:
 
 https://wiki.marklogic.com/pages/viewpageattachments.action?pageId=31359376&highlight=seed-data1.3.tgz
+
+_**If** you are using OSX and have access to the nightly builds site,_ an MLVM script is available to fully configure the Java Middle Tier, including the download/installation of the latest nightly, dowload/loading of seed data and initialization and starup of of the middle-tier:
+
+https://github.com/marklogic/marklogic-samplestack/blob/develop/appserver/java-spring/cleanstart.sh
+
+If you are not using OSX, the script may be helpful in understanding the steps, should you wish to examine it and/or adapt it for your platform.
 
 *end note*
 


### PR DESCRIPTION
Instruct developers to download/use the latest MarkLogic 8.0 nightly.

Make mention of cleanstart.sh script for detailed steps which are being
tested daily and expected to provide a working middle tier, with caveat
that the script will only be functional on OSX.
