### PR TITLE
fetch and extract tasks part of issue 233

### DIFF
--- a/appserver/java-spring/.gitignore
+++ b/appserver/java-spring/.gitignore
@@ -24,3 +24,4 @@ public
 *.ipr
 bin
 src/main/resources/test-server.ldif~
+creds

--- a/appserver/java-spring/README.md
+++ b/appserver/java-spring/README.md
@@ -34,9 +34,9 @@ during the install and setup process.
 * `./gradlew dbConfigureAll`   dbConfigureClean then runs dbConfigure.  Uploads all config files to MarkLogic.
  
 * `./gradlew bootRun`       This command runs the middle tier and MarkLogic services.  This project also contains a built version of the front-end angular application.  If you want to use and exercise the front-end independently, see the sibling project in /browser for instructions on running the browser application
-* `./gradlew dbFetch`  TODO Fetches seed data from a remote location to the build directory.
-* `./gradlew dbExtract`  TODO Fetches seed data from a remote location to the build directory.
-* `./gradlew dbLoad` TODO Runs dbFetch, dbExtract by default as dependencies to loading seed data.
+* `./gradlew seedDataFetch`  Fetches seed data from a remote location to the build directory.
+* `./gradlew seedDataExtract`  Extracts the fetched seed data tgz to within the directory.
+* `./gradlew dbLoad` Runs seedDataFetch, seedDataExtract as dependencies (unless up-to-date) to load seed data.
 * `./gradlew dbClear`  Deletes all data from the database.
  
 * ./gradlew eclipse  is one way to set up this project for use in eclipse.  [wiki link]

--- a/appserver/java-spring/build.gradle
+++ b/appserver/java-spring/build.gradle
@@ -41,7 +41,6 @@ task appserver <<
  * and install security objects.
  */
 task dbInit(type: MarkLogicInitTask)
-
 dbInit.roles = file("../../database/security/roles")
 dbInit.users = file("../../database/security/users")
 
@@ -60,12 +59,12 @@ task dbTeardown(type: MarkLogicTeardownTask)
 task dbConfigure(type: MarkLogicConfigureTask)
 
 task dbConfigureClean << {
-    delete("$buildDir/database")
+    delete("${buildDir}/database")
 }
 
 
 dbConfigure.inputDir = file('../../database')
-dbConfigure.outputDir = file("$buildDir/database")
+dbConfigure.outputDir = file("${buildDir}/database")
 dbConfigure.inputProperty = project.properties['taskInputProperty'] ?: "original"
 dbConfigure.shouldRunAfter dbInit
 dbConfigure.shouldRunAfter dbConfigureClean
@@ -80,11 +79,41 @@ dbConfigureAll.dependsOn dbConfigure
  */
 assemble.dependsOn(dbInit, dbConfigure, test)
 
+/**
+ * FETCH SEED DATA
+ */
+task seedDataFetch(type: MarkLogicFetchTask) {
+    url = "http://developer.marklogic.com/media/gh/seed-data1.3.tgz"
+    destFile = file("${buildDir}/seed.tgz")
+    outputs.file destFile
+ // url "file:///home/cgreer/third_party/seed-1.4.dev.tgz"
+}
+seedDataFetch.dependsOn(processResources)
+
+task seedDataExtract {
+    ext.destDir = file("${buildDir}/seed-data")
+    ext.srcFile = file("${buildDir}/seed.tgz")
+    inputs.file srcFile
+    outputs.dir destDir
+    doLast {
+        destDir.mkdirs()
+        copy {
+            from tarTree(resources.gzip(srcFile))
+                into destDir
+        }
+    }
+}
+seedDataExtract.dependsOn(seedDataFetch)
+
 /*
  * LOAD
  */
-task dbLoad(type: MarkLogicSlurpTask)
+task dbLoad(type: MarkLogicSlurpTask) {
+    seedDirectory = file("${buildDir}/seed-data")  
+    inputs.dir seedDirectory
+}
 dbLoad.mustRunAfter(assemble)
+dbLoad.dependsOn(seedDataExtract)
 /* never skip dbload if requested */
 dbLoad.outputs.upToDateWhen { false }
 

--- a/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicFetchTask.groovy
+++ b/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicFetchTask.groovy
@@ -1,0 +1,19 @@
+import groovy.json.*
+import groovyx.net.http.RESTClient
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+public class MarkLogicFetchTask extends MarkLogicTask {
+
+    String url
+    File destFile
+
+    @TaskAction
+    void fetchSeedData() {
+        logger.warn("Fetching data from " + url)
+        def is = new URL(url).openStream()
+        destFile << is
+
+    }
+
+}

--- a/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicSlurpTask.groovy
+++ b/appserver/java-spring/buildSrc/src/main/groovy/MarkLogicSlurpTask.groovy
@@ -14,12 +14,13 @@ import com.marklogic.client.io.DocumentMetadataHandle.Capability
 
 public class MarkLogicSlurpTask extends MarkLogicTask {
 
-    String seedDirectory = "database/seed-data"
+    File seedDirectory 
 
 	private writerClient() {
 		RESTClient client = new RESTClient("http://" + config.marklogic.rest.host + ":" + config.marklogic.rest.port)
 		client.auth.basic config.marklogic.writer.user, config.marklogic.writer.password
 		client.getEncoder().putAt("application/n-triples", client.getEncoder().getAt("text/plain"))
+		client.getParser().putAt("application/n-triples", client.getParser().getAt("text/plain"))
 		return client
 	}
 
@@ -35,7 +36,7 @@ public class MarkLogicSlurpTask extends MarkLogicTask {
     @TaskAction
     void load() {
 		RESTClient client = writerClient()
-        def jsonFiles = project.fileTree(dir: "../../" + seedDirectory).matching { include '**/*.json' 
+        def jsonFiles = project.fileTree(seedDirectory).matching { include '**/*.json' 
 include '**/*.nt'}
         def BATCH_SIZE = 300
         def numWritten = 0
@@ -43,7 +44,7 @@ include '**/*.nt'}
         def acceptedPermissionMetadata = new DocumentMetadataHandle().withPermission("samplestack-guest", Capability.READ)
         def pojoCollectionMetadata = new DocumentMetadataHandle().withCollections("com.marklogic.samplestack.domain.Contributor")
         jsonFiles.each { 
-            def pattern = Pattern.compile(".*" + "seed-data")
+            def pattern = Pattern.compile(".*" + seedDirectory.name)
             def docUri = it.path.replaceAll(pattern, "").replaceAll("\\\\", "/")
             if (it.path.contains("dbpedia")) {
                 logger.info("PUT RDF data to graph " + docUri)


### PR DESCRIPTION
Here is a step forward for automation.

This commit, which is part of issue 233, EA-3 seed data prep, introduces two new gradle tasks. (They're in the readme.)

./gradlew dbload  still will do the same thing as before : functionally so all the same tests and procedures will work.

The new:
./gradlew seedDataFetch      goes and grabs data from a url.  It's set to the 1.3 seed data so no change in funcionality from now.  (except you can change cleanstart)
./gradlew seedDataExtract    extracts the contents of the tgz. 
./gradlew dbload    now loads the data that was fetched from those processes.

/database/seed-data is no longer used... these files are placed in the build directory.

I think this is ready to go.  Happy to talk over the changes
