### PR TITLE
Change to handle null owner in single-question javascript transform fixe...

### DIFF
--- a/database/transforms/single-question.sjs
+++ b/database/transforms/single-question.sjs
@@ -4,6 +4,13 @@
  * and return a mapping of ids to reputations
  */
 function joinReputation(owner) {
+    if (owner == undefined) {
+        return { "id":"unknown", 
+             "displayName":"unknown", 
+             "userName":"unknown",
+             "reputation":0
+           };
+    }
     var results = cts.search(
                     cts.andQuery( [
                       cts.collectionQuery("com.marklogic.samplestack.domain.Contributor"),


### PR DESCRIPTION
Fixes #312

Pretty straightforward handling for a null user.  Works. with seed data 1.5 verify

/doc/soq15864836

http://stackoverflow.com/questions/15864836/concept-why-does-match-seemingly-strip-parentheses
