### PR TITLE
browser: handle default sorts in search

### DIFF
--- a/appserver/java-spring/build/resources/main/public/_marklogic/domain/mlSearch.js
+++ b/appserver/java-spring/build/resources/main/public/_marklogic/domain/mlSearch.js
@@ -679,12 +679,16 @@ define(['_marklogic/module'], function (module) {
         if (stateParams.sort && stateParams.sort.length) {
           this.criteria.sort = [ stateParams.sort.trim() ];
         }
+        else {
+          this.criteria.sort = null;
+        }
         angular.forEach(this.criteria.constraints, function (constraint) {
           mlUtil.merge(params, self.constraintFromStateParam(
             constraint,
             stateParams
           ));
         });
+
 
         mlUtil.merge(this.criteria, { constraints : params} );
         this.testValidity();

--- a/appserver/java-spring/build/resources/main/public/app/directives/ssSearchResults.html
+++ b/appserver/java-spring/build/resources/main/public/app/directives/ssSearchResults.html
@@ -26,7 +26,7 @@
     <li
       ng-repeat="sort in sorts"
       ng-click="setSort(sort.value)"
-      ng-class="{ 'ss-sort-active': search.criteria.sort[0] == sort.value }"
+      ng-class="{ 'ss-sort-active': getActiveSort() == sort.value }"
       ng-bind-template="{{sort.label}}"
     >
     </li>

--- a/appserver/java-spring/build/resources/main/public/app/directives/ssSearchResults.js
+++ b/appserver/java-spring/build/resources/main/public/app/directives/ssSearchResults.js
@@ -24,12 +24,24 @@ define(['app/module'], function (module) {
         },
         link: function (scope, element, attrs) {
           scope.$watch('search.results', function () {
+
+            scope.getActiveSort = function () {
+              if (!scope.search.criteria.sort) {
+                if (scope.search.criteria.q &&
+                  scope.search.criteria.q.length
+                ) {
+                  return 'relevance';
+                }
+                else {
+                  return 'active';
+                }
+              }
+              else {
+                return scope.search.criteria.sort[0];
+              }
+            };
             //Sort settings
             scope.sorts = [
-              {
-                label: 'relevance',
-                value: ['relevance']
-              },
               {
                 label: 'newest',
                 value: ['active']
@@ -39,6 +51,17 @@ define(['app/module'], function (module) {
                 value: ['votes']
               }
             ];
+
+            if (scope.search.criteria.q &&
+                scope.search.criteria.q.length
+            ) {
+              scope.sorts.unshift(
+                {
+                  label: 'relevance',
+                  value: ['relevance']
+                }
+              );
+            }
 
             scope.setSort = function (sort) {
               scope.search.criteria.sort = sort;

--- a/appserver/java-spring/build/resources/main/public/app/domain/ssSearch.js
+++ b/appserver/java-spring/build/resources/main/public/app/domain/ssSearch.js
@@ -55,7 +55,7 @@ define(['app/module'], function (module) {
               }
             },
             criteria: {
-              sort: ['relevance'],
+              sort: undefined,
               constraints: {
                 resolved: {
                   constraintName: 'resolved',
@@ -181,6 +181,27 @@ define(['app/module'], function (module) {
 
       SsSearchObject.prototype.$mlSpec.serviceName = 'ssSearch';
 
+      SsSearchObject.prototype.getHttpDataPOST = function () {
+        var base = mlSearch.object.prototype
+            .getHttpDataPOST.call(this);
+
+        if (!(this.criteria.sort && this.criteria.sort.length)) {
+          if (this.criteria.q && this.criteria.q.length) {
+            base.query.qtext = [
+              base.query.qtext,
+              'sort:' + 'relevance'
+            ];
+          }
+          if (!this.criteria.q) {
+            base.query.qtext = [
+              base.query.qtext,
+              'sort:' + 'active'
+            ];
+          }
+        }
+
+        return base;
+      };
 
       /**
        * @ngdoc method

--- a/appserver/java-spring/build/resources/main/public/app/states/explore.js
+++ b/appserver/java-spring/build/resources/main/public/app/states/explore.js
@@ -36,7 +36,15 @@ define(['app/module'], function (module) {
         setWatches();
       };
 
-
+      var sortOverride = function () {
+        if (
+          $scope.search.criteria.sort &&
+          $scope.search.criteria.sort[0] === 'relevance' &&
+          (!($scope.search.criteria.q && $scope.search.criteria.q.length))
+        ) {
+          delete $scope.search.criteria.sort;
+        }
+      };
 
       var setWatches = function () {
         var onChange = function (newVal, oldVal) {
@@ -91,6 +99,7 @@ define(['app/module'], function (module) {
       };
 
       $scope.onCriteriaChange = function () {
+        sortOverride();
         $scope.applyScopeToSearch();
         var newStateParams = $scope.search.getStateParams();
         if (newStateParams.q) {

--- a/browser/src/_marklogic/domain/mlSearch.js
+++ b/browser/src/_marklogic/domain/mlSearch.js
@@ -679,12 +679,16 @@ define(['_marklogic/module'], function (module) {
         if (stateParams.sort && stateParams.sort.length) {
           this.criteria.sort = [ stateParams.sort.trim() ];
         }
+        else {
+          this.criteria.sort = null;
+        }
         angular.forEach(this.criteria.constraints, function (constraint) {
           mlUtil.merge(params, self.constraintFromStateParam(
             constraint,
             stateParams
           ));
         });
+
 
         mlUtil.merge(this.criteria, { constraints : params} );
         this.testValidity();

--- a/browser/src/app/directives/ssSearchResults.html
+++ b/browser/src/app/directives/ssSearchResults.html
@@ -26,7 +26,7 @@
     <li
       ng-repeat="sort in sorts"
       ng-click="setSort(sort.value)"
-      ng-class="{ 'ss-sort-active': search.criteria.sort[0] == sort.value }"
+      ng-class="{ 'ss-sort-active': getActiveSort() == sort.value }"
       ng-bind-template="{{sort.label}}"
     >
     </li>

--- a/browser/src/app/directives/ssSearchResults.js
+++ b/browser/src/app/directives/ssSearchResults.js
@@ -24,12 +24,24 @@ define(['app/module'], function (module) {
         },
         link: function (scope, element, attrs) {
           scope.$watch('search.results', function () {
+
+            scope.getActiveSort = function () {
+              if (!scope.search.criteria.sort) {
+                if (scope.search.criteria.q &&
+                  scope.search.criteria.q.length
+                ) {
+                  return 'relevance';
+                }
+                else {
+                  return 'active';
+                }
+              }
+              else {
+                return scope.search.criteria.sort[0];
+              }
+            };
             //Sort settings
             scope.sorts = [
-              {
-                label: 'relevance',
-                value: ['relevance']
-              },
               {
                 label: 'newest',
                 value: ['active']
@@ -39,6 +51,17 @@ define(['app/module'], function (module) {
                 value: ['votes']
               }
             ];
+
+            if (scope.search.criteria.q &&
+                scope.search.criteria.q.length
+            ) {
+              scope.sorts.unshift(
+                {
+                  label: 'relevance',
+                  value: ['relevance']
+                }
+              );
+            }
 
             scope.setSort = function (sort) {
               scope.search.criteria.sort = sort;

--- a/browser/src/app/domain/ssSearch.js
+++ b/browser/src/app/domain/ssSearch.js
@@ -55,7 +55,7 @@ define(['app/module'], function (module) {
               }
             },
             criteria: {
-              sort: ['relevance'],
+              sort: undefined,
               constraints: {
                 resolved: {
                   constraintName: 'resolved',
@@ -181,6 +181,27 @@ define(['app/module'], function (module) {
 
       SsSearchObject.prototype.$mlSpec.serviceName = 'ssSearch';
 
+      SsSearchObject.prototype.getHttpDataPOST = function () {
+        var base = mlSearch.object.prototype
+            .getHttpDataPOST.call(this);
+
+        if (!(this.criteria.sort && this.criteria.sort.length)) {
+          if (this.criteria.q && this.criteria.q.length) {
+            base.query.qtext = [
+              base.query.qtext,
+              'sort:' + 'relevance'
+            ];
+          }
+          if (!this.criteria.q) {
+            base.query.qtext = [
+              base.query.qtext,
+              'sort:' + 'active'
+            ];
+          }
+        }
+
+        return base;
+      };
 
       /**
        * @ngdoc method

--- a/browser/src/app/states/explore.js
+++ b/browser/src/app/states/explore.js
@@ -36,7 +36,15 @@ define(['app/module'], function (module) {
         setWatches();
       };
 
-
+      var sortOverride = function () {
+        if (
+          $scope.search.criteria.sort &&
+          $scope.search.criteria.sort[0] === 'relevance' &&
+          (!($scope.search.criteria.q && $scope.search.criteria.q.length))
+        ) {
+          delete $scope.search.criteria.sort;
+        }
+      };
 
       var setWatches = function () {
         var onChange = function (newVal, oldVal) {
@@ -91,6 +99,7 @@ define(['app/module'], function (module) {
       };
 
       $scope.onCriteriaChange = function () {
+        sortOverride();
         $scope.applyScopeToSearch();
         var newStateParams = $scope.search.getStateParams();
         if (newStateParams.q) {

--- a/browser/test/unit-tests/app/domain/ssSearch.unit.js
+++ b/browser/test/unit-tests/app/domain/ssSearch.unit.js
@@ -32,7 +32,7 @@ define([
           '/v1/search',
           {
             query: {
-              qtext: ['', 'sort:relevance'],
+              qtext: ['', 'sort:active'],
               'and-query': {
                 queries: [ {
                   'range-constraint-query': {
@@ -63,7 +63,7 @@ define([
           '/v1/search',
           {
             query: {
-              qtext: ['', 'sort:relevance'],
+              qtext: ['', 'sort:active'],
               'and-query': {
                 queries: [ {
                   'value-constraint-query': {


### PR DESCRIPTION
If there is no query text and no specified sort, default sort is
'active' (aka newest).

If there is is query text and no specified sort, default sort is
'relevance'.

Omit 'relevance' tab when search does not contain query text.
