### PR TITLE
update to EA-3 for buildScripts

### DIFF
--- a/appserver/java-spring/buildSrc/build.gradle
+++ b/appserver/java-spring/buildSrc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile gradleApi()
     compile("org.codehaus.groovy:groovy-all:2.3.7")
     compile("org.codehaus.groovy.modules.http-builder:http-builder:0.7")
-    compile('com.marklogic:client-api-java:3.0-SNAPSHOT') {
+    compile('com.marklogic:client-api-java:3.0.0-EA3') {
         exclude(group: 'org.slf4j')
         exclude(group: 'ch.qos.logback')
     }


### PR DESCRIPTION
An oversight earlier -- the buildScripts rely on Java Client API as well as Sampletack itself.  This change updates the buildScript dependency to the just -release EA3.
