### PR TITLE
Changes to work with getDocumentUri, new in PojoRepository

### DIFF
--- a/appserver/java-spring/build.gradle
+++ b/appserver/java-spring/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     compile("org.apache.directory.server:apacheds-bootstrap-partition:1.5.5")
     compile("org.apache.directory.server:apacheds-bootstrap-extract:1.5.5")
     compile("joda-time:joda-time:2.4")
-    compile(group: 'com.marklogic', name: 'client-api-java', version: '3.0.0-EA3', changing: false) {
+    compile(group: 'com.marklogic', name: 'client-api-java', version: '3.0-SNAPSHOT', changing: true) {
         exclude(group: 'org.slf4j')
         exclude(group: 'ch.qos.logback')
     }

--- a/appserver/java-spring/buildSrc/build.gradle
+++ b/appserver/java-spring/buildSrc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile gradleApi()
     compile("org.codehaus.groovy:groovy-all:2.3.7")
     compile("org.codehaus.groovy.modules.http-builder:http-builder:0.7")
-    compile('com.marklogic:client-api-java:3.0.0-EA3') {
+    compile('com.marklogic:client-api-java:3.0-SNAPSHOT') {
         exclude(group: 'org.slf4j')
         exclude(group: 'ch.qos.logback')
     }

--- a/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicContributorService.java
+++ b/appserver/java-spring/src/main/java/com/marklogic/samplestack/dbclient/MarkLogicContributorService.java
@@ -195,7 +195,7 @@ public class MarkLogicContributorService extends MarkLogicBaseService implements
 
 		patchBuilder.addPermission("samplestack-guest", Capability.READ);
 		DocumentPatchHandle patch = patchBuilder.build();
-		String uri = contributor.getClass().getCanonicalName() + "/" + contributor.getId() + ".json";
+		String uri = repository.getDocumentUri(contributor);
 		if (transaction == null) {
 			repository.write(contributor);
 			jsonDocumentManager(ClientRole.SAMPLESTACK_CONTRIBUTOR).patch(uri, patch);

--- a/appserver/java-spring/src/main/resources/logback.xml
+++ b/appserver/java-spring/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
 
  <logger name="org.apache.directory" level="ERROR"/>
  <logger name="com.marklogic.client" level="INFO"/>
- <logger name="com.marklogic.samplestack" level="INFO"/>
+ <logger name="com.marklogic.samplestack" level="DEBUG"/>
 
 
 </configuration>

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/database/DatabaseQnADocumentSearchIT.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/database/DatabaseQnADocumentSearchIT.java
@@ -176,7 +176,6 @@ public class DatabaseQnADocumentSearchIT {
 			JsonNode qnaDoc = i.next();
 			for (int j=0; j < qnaResults.size(); j++) {
 				ObjectNode resultObject = (ObjectNode) qnaResults.get(j).get("content");
-
 				logger.debug("In results at " + j + " and " + mapper.writeValueAsString(resultObject));
 				ObjectNode ownerNode = (ObjectNode) resultObject.get("owner");
 				int reputation = ownerNode.get("reputation").asInt();

--- a/appserver/java-spring/src/test/java/com/marklogic/samplestack/mock/MockPojoRepositoryImpl.java
+++ b/appserver/java-spring/src/test/java/com/marklogic/samplestack/mock/MockPojoRepositoryImpl.java
@@ -263,4 +263,9 @@ public class MockPojoRepositoryImpl implements
 		// noop
 	}
 
+	@Override
+	public String getDocumentUri(Contributor pojo) {
+		return "/some-uri.json";
+	}
+
 }

--- a/appserver/java-spring/src/test/resources/questions/20864445.json
+++ b/appserver/java-spring/src/test/resources/questions/20864445.json
@@ -14,7 +14,9 @@
     "lastActivityDate": "2014-01-01T00:07:38.573",
     "owner": {
         "displayName": "Joe Bid",
-        "id": "2785133"
+        "id": "2785133",
+        "userName":"joebid@email.com",
+        "reputation":0
     },
     "tags": [
         "graphics",

--- a/appserver/java-spring/src/test/resources/questions/20864449.json
+++ b/appserver/java-spring/src/test/resources/questions/20864449.json
@@ -9,7 +9,9 @@
     "lastActivityDate": "2014-01-01T00:09:20.590",
     "owner": {
         "displayName": "CodeKing",
-        "id": "3017954"
+        "id": "3017954",
+        "userName":"SuperKind@email.com",
+        "reputation":0
     },
     "tags": [
         "mysql",


### PR DESCRIPTION
This commit BREAKS compatibility with the EA-3 server.  
It updates the Java code to work with a new snapshot (already deployed) but doesn't do anything else interesting.

After this merges, we should expect to keep current with server HEAD
