### PR TITLE
browser: reinstate ISO 8601 strings

### DIFF
--- a/appserver/java-spring/static/_marklogic/domain/mlSearch.js
+++ b/appserver/java-spring/static/_marklogic/domain/mlSearch.js
@@ -442,8 +442,7 @@ define(['_marklogic/module'], function (module) {
               q.value = constraint.value;
             }
             if (constraint.type === 'dateTime') {
-              q.value = constraint.value.toISOString()
-                  .replace(/Z.*/, '');
+              q.value = constraint.value.toISOString();
             }
             if (constraint.type === 'boolean') {
               q.boolean = constraint.value;
@@ -542,7 +541,7 @@ define(['_marklogic/module'], function (module) {
             // the type conigured on the server while not expsoing the user
             // to times
             param[constraint.queryStringName] =
-                constraint.value.toISOString().replace(/Z.*/, '');
+                constraint.value.toISOString();
           }
         }
         if (constraint.type === 'boolean' ) {
@@ -645,7 +644,9 @@ define(['_marklogic/module'], function (module) {
         }
         if (constraint.type === 'dateTime') {
           if (trimmed && trimmed.length) {
-            constraint.value = mlUtil.moment(trimmed);
+            constraint.value = mlUtil.moment(
+              trimmed, [mlUtil.moment.ISO_8601, 'MM-DD-YYYY']
+            );
           }
           else {
             constraint.value = null;

--- a/appserver/java-spring/static/_marklogic/services/util/mlUtil.js
+++ b/appserver/java-spring/static/_marklogic/services/util/mlUtil.js
@@ -47,24 +47,7 @@ define([
 
   module.value('mlUtil', {
 
-    moment: moment.utc,
-
-    /**
-     * @ngdoc method
-     * @name mlUtil#stripZone
-     * @param {object} dateish A JavaScript or `moment` date object
-     * @returns {string} an ISO8601 string representing the date, with time
-     * zone
-     * information removed.
-     *
-     * This function will be unnecessary when time zones and date string
-     * handling is fully implemented. For now, it is used to ensure that the
-     * middle tier doesn't get ISO8601 time zone information that it cannot
-     * process.
-     */
-    stripZone: function (dateish) {
-      return dateish.toISOString().replace(/Z.*$/, '');
-    },
+    moment: moment,
 
     /**
      * @ngdoc method

--- a/appserver/java-spring/static/app/directives/ssFacetDateRange.js
+++ b/appserver/java-spring/static/app/directives/ssFacetDateRange.js
@@ -385,18 +385,14 @@ define(['app/module'], function (module) {
 
                 var dateToPickerStart = function (val) {
                   return val ?
-                      new Date(mlUtil.stripZone(
-                        mlUtil.moment(val))
-                      ) :
-                    null;
+                      new Date(mlUtil.moment(val)) :
+                      null;
                 };
 
                 var dateToPickerEnd = function (val) {
                   return val ?
-                      new Date(mlUtil.stripZone(
-                        mlUtil.moment(val).subtract('d', 1)
-                      )) :
-                    null;
+                      new Date(mlUtil.moment(val).subtract('d', 1)) :
+                      null;
                 };
 
                 if (newData.length) {

--- a/browser/src/_marklogic/domain/mlSearch.js
+++ b/browser/src/_marklogic/domain/mlSearch.js
@@ -442,8 +442,7 @@ define(['_marklogic/module'], function (module) {
               q.value = constraint.value;
             }
             if (constraint.type === 'dateTime') {
-              q.value = constraint.value.toISOString()
-                  .replace(/Z.*/, '');
+              q.value = constraint.value.toISOString();
             }
             if (constraint.type === 'boolean') {
               q.boolean = constraint.value;
@@ -542,7 +541,7 @@ define(['_marklogic/module'], function (module) {
             // the type conigured on the server while not expsoing the user
             // to times
             param[constraint.queryStringName] =
-                constraint.value.toISOString().replace(/Z.*/, '');
+                constraint.value.toISOString();
           }
         }
         if (constraint.type === 'boolean' ) {
@@ -645,7 +644,9 @@ define(['_marklogic/module'], function (module) {
         }
         if (constraint.type === 'dateTime') {
           if (trimmed && trimmed.length) {
-            constraint.value = mlUtil.moment(trimmed);
+            constraint.value = mlUtil.moment(
+              trimmed, [mlUtil.moment.ISO_8601, 'MM-DD-YYYY']
+            );
           }
           else {
             constraint.value = null;

--- a/browser/src/_marklogic/services/util/mlUtil.js
+++ b/browser/src/_marklogic/services/util/mlUtil.js
@@ -47,24 +47,7 @@ define([
 
   module.value('mlUtil', {
 
-    moment: moment.utc,
-
-    /**
-     * @ngdoc method
-     * @name mlUtil#stripZone
-     * @param {object} dateish A JavaScript or `moment` date object
-     * @returns {string} an ISO8601 string representing the date, with time
-     * zone
-     * information removed.
-     *
-     * This function will be unnecessary when time zones and date string
-     * handling is fully implemented. For now, it is used to ensure that the
-     * middle tier doesn't get ISO8601 time zone information that it cannot
-     * process.
-     */
-    stripZone: function (dateish) {
-      return dateish.toISOString().replace(/Z.*$/, '');
-    },
+    moment: moment,
 
     /**
      * @ngdoc method

--- a/browser/src/app/directives/ssFacetDateRange.js
+++ b/browser/src/app/directives/ssFacetDateRange.js
@@ -385,18 +385,14 @@ define(['app/module'], function (module) {
 
                 var dateToPickerStart = function (val) {
                   return val ?
-                      new Date(mlUtil.stripZone(
-                        mlUtil.moment(val))
-                      ) :
-                    null;
+                      new Date(mlUtil.moment(val)) :
+                      null;
                 };
 
                 var dateToPickerEnd = function (val) {
                   return val ?
-                      new Date(mlUtil.stripZone(
-                        mlUtil.moment(val).subtract('d', 1)
-                      )) :
-                    null;
+                      new Date(mlUtil.moment(val).subtract('d', 1)) :
+                      null;
                 };
 
                 if (newData.length) {

--- a/browser/test/unit-tests/_marklogic/domain/mlSearch.unit.js
+++ b/browser/test/unit-tests/_marklogic/domain/mlSearch.unit.js
@@ -311,7 +311,7 @@ define([
               'and-query': { queries: [
                 { 'range-constraint-query' : {
                   'constraint-name': 'dummy',
-                  value: '2001-01-01T00:00:00.000'
+                  value: mlUtil.moment('2001-01-01T00:00:00Z')
                 } }
               ] }
             }
@@ -327,7 +327,7 @@ define([
                 constraintType: 'range',
                 queryStringName: 'dummy',
                 type: 'dateTime',
-                value: mlUtil.moment('2001-01-01')
+                value: mlUtil.moment('2001-01-01T00:00:00Z')
               }
             }
           }
@@ -409,13 +409,13 @@ define([
             dummy: {
               queryStringName: 'test-name',
               type: 'dateTime',
-              value: mlUtil.moment('2001-01-01')
+              value: mlUtil.moment('2001-01-01T00:00:00.000Z')
             }
           }
         } });
         s.getStateParams().should.have.property(
           'test-name',
-          mlUtil.moment('2001-01-01').toISOString().replace(/Z.*/, '')
+          mlUtil.moment('2001-01-01T00:00:00.000Z').toISOString()
         );
       });
 
@@ -541,7 +541,7 @@ define([
           a: 'yes',
           b: 'test',
           c: '1,2',
-          d: '2001-01-01',
+          d: mlUtil.moment('2001-01-01T00:00:00.000Z').toISOString(),
           e: '',
           f: '',
           g: '',
@@ -553,7 +553,8 @@ define([
 
         s.criteria.q.should.equal('stuff');
         expect(s.getCurrentPage()).to.equal(2);
-        s.criteria.constraints.should.deep.equal({
+
+        var expectation = {
           a: { type: 'boolean', queryStringName: 'a', value: true },
           b: { type: 'text', queryStringName: 'b', value: 'test' },
           c: {
@@ -565,7 +566,7 @@ define([
           d: {
             type: 'dateTime',
             queryStringName: 'd',
-            value: mlUtil.moment('2001-01-01')
+            value: mlUtil.moment('2001-01-01T00:00:00.000Z')
           },
           e: {
             type: 'enum',
@@ -592,7 +593,9 @@ define([
             queryStringName: 'i',
             value: false
           }
-        });
+        };
+        JSON.stringify(s.criteria.constraints)
+            .should.deep.equal(JSON.stringify(expectation));
       });
 
       it('should throw for unsupported methods', function () {

--- a/browser/test/unit-tests/app/domain/ssSearch.unit.js
+++ b/browser/test/unit-tests/app/domain/ssSearch.unit.js
@@ -25,7 +25,7 @@ define([
         var self = this;
         var s = ssSearch.create({
           criteria: { constraints: { dateStart: {
-            value: mlUtil.moment('2014-08-01')
+            value: mlUtil.moment('2014-08-01T00:00:00.000-05:00')
           } } }
         });
         $httpBackend.expectPOST(
@@ -37,7 +37,7 @@ define([
                 queries: [ {
                   'range-constraint-query': {
                     'constraint-name': 'lastActivity',
-                    'value': '2014-08-01T00:00:00.000',
+                    'value': mlUtil.moment('2014-08-01T00:00:00.000-05:00'),
                     'range-operator': 'GE'
                   }
                 } ]


### PR DESCRIPTION
Throughout app, discontinue forcing dates into UTC/assumptions of GMT.

Instead, allow time zones/offsets to be included.
